### PR TITLE
Expand controller lookup by ID

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from airport_controllers_api import load_data, get_controllers
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_data():
+    load_data()
+
+
+def test_edja_topdown_controllers():
+    ctrs = get_controllers('EDJA')
+    ids = {c['id'] for c in ctrs}
+    expected = {'ILR', 'SWA', 'FUE', 'ZUG', 'STA', 'TRU', 'RDG'}
+    assert expected.issubset(ids)
+    # EDJA has no other references, so exactly this set
+    assert ids == expected
+


### PR DESCRIPTION
## Summary
- support looking up controller positions by id
- collect airport `topdown` ids separately
- fetch controllers listed in `topdown`
- add regression test for EDJA to cover topdown IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684933e51cb48320bbfe103520c9feea